### PR TITLE
lower EzXML requirement to 0.4.2

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-EzXML 0.4.4
+EzXML 0.4.2
 Unitful
 FixedPointNumbers
 Colors


### PR DESCRIPTION
tests seem to pass via `Pkg.clone("https://github.com/tlnagy/OMETIFF.jl"); Pkg.pin("EzXML",v"0.4.2"); Pkg.test("OMETIFF"); Pkg.free("EzXML")`