### PR TITLE
add support for bundling acquisition comments with data

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,5 @@ Colors
 AxisArrays
 DataStructures
 Images
+ImageMetadata
+JSON

--- a/src/OMETIFF.jl
+++ b/src/OMETIFF.jl
@@ -9,6 +9,8 @@ using Colors
 using EzXML
 using FileIO
 using DataStructures
+using JSON
+using ImageMetadata
 using Images
 
 include("utils.jl")

--- a/src/files.jl
+++ b/src/files.jl
@@ -158,3 +158,21 @@ function _next(file::TiffFile, offset::Int)
     next_ifd = do_bswap(file, read(file.io, UInt32))
     next_ifd, strip_offset_list
 end
+
+
+function load_comments(file)
+    seek(file.io, 24)
+    comment_header = Int(do_bswap(file, read(file.io, UInt32)))
+    if comment_header != 99384722
+        return ""
+    end
+    comment_offset = Int(do_bswap(file, read(file.io, UInt32)))
+    seek(file.io, comment_offset)
+    comment_header = read(file.io, UInt32)
+    comment_length = Int(do_bswap(file, read(file.io, UInt32)))
+    metadata = JSON.parse(String(read(file.io, UInt8, comment_length)))
+    if !haskey(metadata, "Summary")
+        return ""
+    end
+    metadata["Summary"]
+end

--- a/src/loader.jl
+++ b/src/loader.jl
@@ -10,6 +10,7 @@ function load(io::Stream{format"OMETIFF"})
     end
 
     orig_file = TiffFile(io)
+    summary = load_comments(orig_file)
 
     # load master OME-XML that contains all information about this dataset
     omexml = load_master_xml(orig_file)
@@ -96,7 +97,7 @@ function load(io::Stream{format"OMETIFF"})
         # TODO: Reduce the number of allocations here
     end
     squeezed_data = squeeze(Gray.(reinterpret(mappedtype, data)), (find(master_dims .== 1)...))
-    AxisArray(squeezed_data, get(axes_dims)[master_dims .> 1]...)
+    ImageMeta(AxisArray(squeezed_data, get(axes_dims)[master_dims .> 1]...), Summary=summary)
 end
 
 """Corresponding Julian types for OME-XML types"""

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,7 +24,7 @@ function myendian()
 end
 
 
-do_bswap(file, value) = file.need_bswap ? bswap.(value) : value
+@inline do_bswap(file, value) = file.need_bswap ? bswap.(value) : value
 
 """
     check_bswap(io::Union{Stream, IOStream})


### PR DESCRIPTION
Eventually, I hope to expose most, if not all, metadata contained within
the OME-TIFF in the returned image.