### PR TITLE
Fix Micro-Manager (and other?) byte order

### DIFF
--- a/src/loader.jl
+++ b/src/loader.jl
@@ -76,7 +76,7 @@ function load(io::Stream{format"OMETIFF"})
 
                 n_strips = length(strip_offsets)
                 strip_len = floor(Int, (width * height) / n_strips)
-                read_dims = n_strips > 1 ? (strip_len) : (height, width)
+                read_dims = n_strips > 1 ? (strip_len) : (width, height)
 
                 # TODO: This shouldn't be allocated for each ifd
                 tmp = Array{get(master_rawtype)}(read_dims...)
@@ -85,9 +85,9 @@ function load(io::Stream{format"OMETIFF"})
                     read!(file.io, tmp)
                     tmp = file.need_bswap ? bswap.(tmp) : tmp
                     if n_strips > 1
-                        data[j, :, ifd.z_idx, ifd.c_idx, ifd.t_idx, pos_idx]= tmp
+                        data[j, :, ifd.z_idx, ifd.c_idx, ifd.t_idx, pos_idx] = tmp
                     else
-                        data[:, :, ifd.z_idx, ifd.c_idx, ifd.t_idx, pos_idx] = tmp
+                        data[:, :, ifd.z_idx, ifd.c_idx, ifd.t_idx, pos_idx] = tmp'
                     end
                 end
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,7 +83,8 @@ end
 @testset "TIFF value verifications" begin
     files = [
         "testdata/singles/170918_tn_neutrophil_migration_wave.ome.tif",
-        "testdata/singles/single-channel.ome.tif"
+        "testdata/singles/single-channel.ome.tif",
+        "testdata/singles/background_1_MMStack.ome.tif"
     ]
     for filepath in files
         # open file using OMETIFF.jl


### PR DESCRIPTION
Micro-Manager apparently stores pixel values in xy (or cols, rows) order,
not yx. Many of the ome.tiff test images contain 1-row strips, which were handled
correctly here.

Before this commit, square images would be transposed, and rectangular images
would show banding because the tmp buffer was being filled in the wrong order.