### PR TITLE
add support for extracting elapsed time from the omexml

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -158,7 +158,7 @@ function get_elapsed_times(containers::Vector{EzXML.Node}, master_dims::NamedTup
 
     # get the used dims that aren't x or y (since each xy plane has one elapsed time)
     nonxydims = NamedTuple{Tuple(k for (k, v) in pairs(master_dims) if k != :X && k != :Y && v > 1)}(master_dims)
-    elapsed_times = fill(0.0*default_unit, values(nonxydims))
+    elapsed_times = fill(NaN*default_unit, values(nonxydims))
 
     # OMETIFF stores the Z, T, C info for each plane in TheZ, TheT, and TheC attributes
     attrnames = ["The$k" for k in keys(nonxydims) if k != :P]

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -1,9 +1,18 @@
-function getattribute(tiffdata::EzXML.Node, attr::String)
+function getattribute(tiffdata::EzXML.Node, ::Type{Int}, attr::String)
     try
         parse(Int, tiffdata[attr])+1
     catch e
         (!isa(e, KeyError)) && rethrow(e)
         -1
+    end
+end
+
+function getattribute(tiffdata::EzXML.Node, ::Type{Float64}, attr::String)
+    try
+        parse(Float64, tiffdata[attr])
+    catch e
+        (!isa(e, KeyError)) && rethrow(e)
+        NaN
     end
 end
 
@@ -53,9 +62,9 @@ function ifdindex!(ifd_index::Array{Union{NTuple{4, Int}, Nothing}},
         end
 
         # get Z, C, T indices (in order specified by `dims`)
-        indices = Tuple(getattribute(tiffdata, "First$x") for x in keys(dims)[3:5])
+        indices = Tuple(getattribute(tiffdata, Int, "First$x") for x in keys(dims)[3:5])
         # how many ifds does this tiffdata correspond to
-        p = getattribute(tiffdata, "PlaneCount") - 1
+        p = getattribute(tiffdata, Int, "PlaneCount") - 1
 
         # if none of the Z, C, T indices are specified then we'll assume the
         # indices starting with the inner dimension, etc
@@ -136,4 +145,51 @@ function build_axes(image::EzXML.Node)
     axes = [Axis{axis_name_mapping[key]}(vals[key]) for key in keys(dims)]
 
     dims, axes
+end
+
+
+"""
+    get_elapsed_times(containers, master_dims, masteraxis; default_unit)
+
+Extracts the actual acquisition times from the OME-XML data. Takes `containers`, a vector of the XML nodes
+corresponding to the root of each image.
+"""
+function get_elapsed_times(containers::Vector{EzXML.Node}, master_dims::NamedTuple, masteraxis::Vector{Axis}; default_unit=Unitful.s)
+
+    # get the used dims that aren't x or y (since each xy plane has one elapsed time)
+    nonxydims = NamedTuple{Tuple(k for (k, v) in pairs(master_dims) if k != :X && k != :Y && v > 1)}(master_dims)
+    elapsed_times = fill(0.0*default_unit, values(nonxydims))
+
+    # OMETIFF stores the Z, T, C info for each plane in TheZ, TheT, and TheC attributes
+    attrnames = ["The$k" for k in keys(nonxydims) if k != :P]
+    didx = fill(1, length(nonxydims))
+
+    # we have to track position independently since it isn't stored in the plane tags
+    # get which index corresponds to position (usually it's last)
+    posdim = findfirst(x->x==:P, keys(nonxydims))
+    unitstr = string(default_unit)
+
+    for (pos, container) in enumerate(containers)
+        planes = findall("ns:Plane[@DeltaT]", container, ["ns"=>namespace(container)])
+
+        for plane in planes
+            for d in 1:length(didx)
+                # if this is the position dimension, get it from the current Pixel object since it's
+                # not stored in the plane itself
+                if d == posdim
+                    didx[d] = pos
+                else
+                    didx[d] = getattribute(plane, Int, attrnames[d])
+                end
+            end
+            try
+                unitstr = plane["DeltaTUnit"]
+            catch
+            end
+            unittype = @eval @u_str $unitstr
+            elapsed_times[didx...] = getattribute(plane, Float64, "DeltaT")*unittype
+        end
+    end
+    used_axes = (masteraxis[i] for i in findall(x->x in keys(nonxydims), keys(master_dims)))
+    AxisArray(elapsed_times, used_axes...)
 end

--- a/test/elapsedtime.jl
+++ b/test/elapsedtime.jl
@@ -1,0 +1,63 @@
+@testset "Only T axis" begin
+    planes = []
+
+    dims = (X=512, Y=512, Z=1, C=1, T=10, P=1)
+    axes = [Axis{:x}(), Axis{:y}(), Axis{:z}(), Axis{:channel}(1), Axis{:time}(1:10), Axis{:position}(1)]
+
+    for t=0:9
+        push!(planes, """<Plane DeltaT="$(t*10.0)" DeltaTUnit="ms" TheC="0" TheT="$t" TheZ="0"/>""")
+    end
+    container = root(parsexml(wrap(join(planes, "\n\t"))))
+
+    @test all(OMETIFF.get_elapsed_times([container], dims, axes; default_unit=Unitful.ms).data .== collect(0:10:90)*u"ms")
+end
+
+@testset "Missing DeltaT" begin
+    planes = []
+
+    dims = (X=512, Y=512, Z=1, C=1, T=10, P=1)
+    axes = [Axis{:x}(), Axis{:y}(), Axis{:z}(), Axis{:channel}(1), Axis{:time}(1:10), Axis{:position}(1)]
+
+    for t=0:9
+        push!(planes, """<Plane TheC="0" TheT="$t" TheZ="0"/>""")
+    end
+    container = root(parsexml(wrap(join(planes, "\n\t"))))
+
+    @test all(isnan.(OMETIFF.get_elapsed_times([container], dims, axes; default_unit=Unitful.ms)))
+end
+
+@testset "Multiple dimensions" begin
+    planes = []
+
+    dims = (X=512, Y=512, Z=1, C=2, T=10, P=3)
+    axes = [Axis{:x}(), Axis{:y}(), Axis{:z}(), Axis{:channel}(1:2), Axis{:time}(1:10), Axis{:position}(1:3)]
+
+    containers = EzXML.Node[]
+    for p in 1:3
+        for t in 1:10, c in 1:2
+            push!(planes, """<Plane DeltaT="$(t*p*c)" TheC="$(c-1)" TheT="$(t-1)" TheZ="0"/>""")
+        end
+        push!(containers, root(parsexml(wrap(join(planes, "\n\t")))))
+    end
+
+    output = OMETIFF.get_elapsed_times(containers, dims, axes; default_unit=Unitful.ms)
+    @test all(size(output) .== (2, 10, 3))
+    @test all(output[Axis{:position}(2), Axis{:channel}(1)] .== collect(2:2:20.0)*u"ms")
+end
+
+@testset "Mixed units" begin
+    planes = []
+
+    dims = (X=512, Y=512, Z=1, C=1, T=10, P=1)
+    axes = [Axis{:x}(), Axis{:y}(), Axis{:z}(), Axis{:channel}(1), Axis{:time}(1:10), Axis{:position}(1)]
+
+    for t in 1:10
+        unit = "ms"
+        (iseven(t)) && (unit = "s")
+        push!(planes, """<Plane DeltaT="$((t+1)÷2*10.0)" DeltaTUnit="$unit" TheC="0" TheT="$(t-1)" TheZ="0"/>""")
+    end
+    container = root(parsexml(wrap(join(planes, "\n\t"))))
+
+    output = OMETIFF.get_elapsed_times([container], dims, axes; default_unit=Unitful.ms)
+    @test all(output[1:2:end]*1000 .== output[2:2:end]) # the evens are in seconds so they should be 1000 times the odd values
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,14 @@ using Unitful
 using AxisArrays
 using Test
 
+include("utils.jl")
+
 @testset "TiffData Layouts" begin
     include("tiffdatas.jl")
+end
+
+@testset "Elapsed Time" begin
+    include("elapsedtime.jl")
 end
 
 @testset "Axes Values" begin

--- a/test/tiffdatas.jl
+++ b/test/tiffdatas.jl
@@ -3,16 +3,6 @@ using EzXML
 # Tests for TiffData adapted from
 # https://docs.openmicroscopy.org/ome-model/5.5.4/ome-tiff/specification.html
 
-wrap(content) = """
-<?xml version="1.0" encoding="UTF-8"?>
-<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
-     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
-     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
-     http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
-    $content
-</OME>"""
-
 function get_result(ifd_index, ifd_files, dimlist)
     io = IOBuffer()
     for (idx, ifd) in enumerate(ifd_index)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,9 @@
+wrap(content) = """
+<?xml version="1.0" encoding="UTF-8"?>
+<OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+     xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06
+     http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd">
+    $content
+</OME>"""


### PR DESCRIPTION
Implements #27

- [x] Need tests


Example:
```julia
julia> img = load("migrating_hl60s_gems_preosmo_1_MMStack.ome.tif");

julia> img["Elapsed_Times"]
1000-element AxisArrays.AxisArray{Unitful.Quantity{Float64,𝐓,Unitful.FreeUnits{(s,),𝐓,nothing}},1,Array{Unitful.Quantity{Float64,𝐓,Unitful.FreeUnits{(s,),𝐓,nothing}},1},Tuple{AxisArrays.Axis{:time,UnitRange{Int64}}}}:
              2.422 s
              2.437 s
 2.4600100097656252 s
  2.479010009765625 s
  2.502010009765625 s
  2.521010009765625 s
  2.544010009765625 s
  2.563010009765625 s
  2.586010009765625 s
 2.6050100097656252 s
   2.62802001953125 s
   2.64702001953125 s
   2.67002001953125 s
   2.68902001953125 s
 2.7120200195312503 s
   2.73102001953125 s
   2.75002001953125 s
   2.77302001953125 s
   2.79202001953125 s
  2.815030029296875 s
  2.834030029296875 s
  2.857030029296875 s
 2.8760300292968752 s
  2.899030029296875 s
  2.918030029296875 s
  2.941030029296875 s
  2.960030029296875 s
```