### PR TITLE
switch to the lightweight ImageShow for show funcs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 julia:
   - 1.0 
+  - 1.2
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageMetadata = "bc367c6b-8a6b-528e-b4bd-a4b897500b49"
-Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+ImageShow = "4e3cecfd-b093-5904-9786-8bbb286a6a31"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 

--- a/src/OMETIFF.jl
+++ b/src/OMETIFF.jl
@@ -10,7 +10,7 @@ using EzXML
 using FileIO
 using JSON
 using ImageMetadata
-using Images
+using ImageShow
 
 include("utils.jl")
 include("files.jl")


### PR DESCRIPTION
should reduce unnecessary dependencies since Images was only used for
the optimized show functions