### PR TITLE
fix accidental transposition that broke rectangular image loading

### DIFF
--- a/src/loader.jl
+++ b/src/loader.jl
@@ -134,7 +134,7 @@ function inmemoryarray(ifds::OrderedDict{NTuple{4, Int}, IFD},
 
     data = Array{rawtype, length(dims)}(undef, dims...)
 
-    height, width = dims[1], dims[2]
+    width, height = dims[1], dims[2]
     # assume no strips
     tmp = Array{rawtype}(undef, height, width)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,3 +176,11 @@ end
     expected = """<OME xmlns=\"http://www.openmicroscopy.org/Schemas/OME/2016-06\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" Creator=\"OME Bio-Formats 5.2.2\" UUID=\"urn:uuid:2bc2aa39-30d2-44ee-8399-c513492dd5de\" xsi:schemaLocation=\"http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd\">\n  <Image ID=\"Image:0\" Name=\"single-channel.ome.tif\">\n    <Pixels BigEndian=\"true\" DimensionOrder=\"XYZCT\" ID=\"Pixels:0\" SizeC=\"1\" SizeT=\"1\" SizeX=\"439\" SizeY=\"167\" SizeZ=\"1\" Type=\"int8\">\n      <Channel ID=\"Channel:0:0\" SamplesPerPixel=\"1\">\n        <LightPath/>\n      </Channel>\n      <TiffData FirstC=\"0\" FirstT=\"0\" FirstZ=\"0\" IFD=\"0\" PlaneCount=\"1\">\n        <UUID FileName=\"single-channel.ome.tif\">urn:uuid:2bc2aa39-30d2-44ee-8399-c513492dd5de</UUID>\n      </TiffData>\n    </Pixels>\n  </Image>\n</OME>"""
     @test OMETIFF.dump_omexml(joinpath("testdata", "singles", "single-channel.ome.tif")) == expected
 end
+
+@testset "Issue #60" begin
+    open(joinpath("testdata", "singles", "nonstriped_rect", "MMStack_Pos0.ome.tif")) do f
+        s = Stream(format"OMETIFF", f, OMETIFF.extract_filename(f))
+        img = OMETIFF.load(s)
+        @test size(img) == (2160, 2560, 8)
+    end
+end


### PR DESCRIPTION
This must've snuck past the tests because all of my images are square or rectangular with strips, but no non-striped rectangular images.

Fixes #60 

- [x] add test