### PR TITLE
fix empty namespace warning triggered by https://github.com/JuliaIO/EzXML.jl/pull/128

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OMETIFF"
 uuid = "2d0ec36b-e807-5756-994b-45af29551fcf"
 authors = ["Tamas Nagy <tamas@tamasnagy.com>"]
-version = "0.3.9"
+version = "0.3.10"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"

--- a/src/loader.jl
+++ b/src/loader.jl
@@ -37,7 +37,7 @@ function load(io::Stream{format"OMETIFF"}; dropunused=true, inmemory=true)
     omexml = load_master_xml(orig_file)
 
     # find all images in this dataset, can either have the Image or Pixel tag
-    containers = findall("//*[@DimensionOrder]", omexml)
+    containers = findall("//*[@DimensionOrder]", omexml, ["ns" => namespace(omexml)])
 
     pos_names = nodecontent.(findall("/ns:OME/ns:Image/ns:StageLabel[@Name]/@Name", omexml, ["ns"=>namespace(omexml)]))
     # if all position names aren't unique then substitute names

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using FileIO
 using Unitful
 using AxisArrays
 using Test
+using ImageMetadata
 
 include("utils.jl")
 
@@ -88,7 +89,7 @@ end
                     tiffslice = open("testdata/singles/181003_slices/P$(pos)_T$(tp).tif") do s
                         FileIO.load(OMETIFF.getstream(format"TIFF", s))
                     end
-                    omeslice = img[Axis{:position}(pos), Axis{:time}(tp+1)].data
+                    omeslice = arraydata(img[Axis{:position}(pos), Axis{:time}(tp+1)])
                     # verify that ometiff slices are correctly indexed
                     @testset "Testing P$(pos)_T$(tp).tif" begin
                         @test all(omeslice .== tiffslice)
@@ -142,7 +143,7 @@ end
             FileIO.load(OMETIFF.getstream(format"TIFF", f))
         end
         # compare
-        @test all(ome.data .== tiff)
+        @test all(arraydata(ome) .== tiff)
     end
 end
 

--- a/test/tiffdatas.jl
+++ b/test/tiffdatas.jl
@@ -24,7 +24,7 @@ function get_ifds(fragment::String)
 end
 
 function get_ifds(omexml::EzXML.Node)
-    containers = findall("//*[@DimensionOrder]", omexml)
+    containers = findall("//*[@DimensionOrder]", omexml, ["ns" => namespace(omexml)])
     dimlist = []
     for container in containers
         dims, _ = OMETIFF.build_axes(container)


### PR DESCRIPTION
Explicitly naming the namespace makes the warning go away.