### PR TITLE
Fix crash when attempting to reopen a stream on mmap access

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OMETIFF"
 uuid = "2d0ec36b-e807-5756-994b-45af29551fcf"
 authors = ["Tamas Nagy <tamas@tamasnagy.com>"]
-version = "0.3.10"
+version = "0.3.11"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"

--- a/src/mmap.jl
+++ b/src/mmap.jl
@@ -54,7 +54,7 @@ function Base.getindex(A::ReadonlyTiffDiskArray{Gray{T}, R, N1, N2}, i1::Int, i2
     # if the file isn't open, lets open a handle and update it
     if !isopen(ifd.file.io)
         path = ifd.file.filepath
-        ifd.file.io = getstream(open(path), path)
+        ifd.file.io = getstream(open(path))
     end
 
     n_strips = length(ifd.strip_offsets)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -165,6 +165,10 @@ end
             @test all(img[1:10,1,1,1] .== img2[1:10,1,1,1])
             # file is read only and should throw an error if you try and modify it
             @test_throws ErrorException img[1:10,1,1,1] .= 1.0
+
+            # test reopening the file stream on access if closed
+            close(s)
+            @test img[10, 10, 2, 1] == img2[10, 10, 2, 1]
         end
     end
 end


### PR DESCRIPTION
introduced in #76 and wasn't caught due a gap in coverage