### PR TITLE
mimic git submodule using plain git command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.ipynb
 Manifest.toml
 docs/build/
+exampletiffs/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "exampletiffs"]
-	path = exampletiffs
-	url = https://github.com/tlnagy/exampletiffs.git

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,10 +21,12 @@ end
 project_root = isfile("runtests.jl") ? abspath("..") : abspath(".")
 testdata_dir = joinpath(project_root, "exampletiffs", "ometiff_testdata")
 if !isdir(testdata_dir)
-    run(`git -C $project_root submodule init`)
-    run(`git -C $project_root submodule update --remote`)
+    run(`git -C $project_root clone https://github.com/tlnagy/exampletiffs.git exampletiffs --branch master --depth 1`)
 else
-    run(`git -C $project_root submodule update --remote`)
+    run(`git -C $testdata_dir fetch`)
+    # for reproducibility we should use hard reset
+    # run(`git -C $testdata_dir reset --hard origin/master`)
+    run(`git -C $testdata_dir pull`)
 end
 
 @testset "Axes Values" begin


### PR DESCRIPTION
This basically mimics the concept of git submodule _for our test purposes_ but works around the Pkg limitation https://github.com/JuliaLang/Pkg.jl/issues/708.

```julia
(@v1.7) pkg> activate --temp
  Activating new project at `/var/folders/c0/p23z1x6x3jg_qtqsy_r421y40000gn/T/jl_AqyJHn`

(jl_AqyJHn) pkg> add https://github.com/johnnychen94/OMETIFF.jl.git#jc/no_submodule
...
Precompiling project...
  7 dependencies successfully precompiled in 31 seconds (48 already precompiled)
```