### PR TITLE
Fix multi-image BoundsError

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OMETIFF"
 uuid = "2d0ec36b-e807-5756-994b-45af29551fcf"
 authors = ["Tamas Nagy <tamas@tamasnagy.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -51,9 +51,11 @@ function ifdindex!(ifd_index::OrderedDict{Int, NTuple{4, Int}},
     tiffdatas = findall(".//ns:TiffData", image, ["ns"=>namespace(image)])
 
     ifd = 1
-    # this is an offset value since multiple ifds can share the same index if
-    # they are split across files, IFD1 (File1), IFD1 (File2), etc
-    prev_ifd = length(obs_filepaths)
+    # to avoid overwriting previous IFD indices from other images, we make sure
+    # to start counting from the maximum previously observed IFD index. 
+    #
+    # TODO: This assumes a dense numbering of the indices, is this always true?
+    prev_ifd = length(ifd_index) > 0 ? maximum(keys(ifd_index)) : 0
     for tiffdata in tiffdatas
         try # if this tiffdata specifies the corresponding IFD
             ifd = parse(Int, tiffdata["IFD"]) + 1

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -53,7 +53,7 @@ function ifdindex!(ifd_index::OrderedDict{Int, NTuple{4, Int}},
     ifd = 1
     # this is an offset value since multiple ifds can share the same index if
     # they are split across files, IFD1 (File1), IFD1 (File2), etc
-    prev_ifd = 0
+    prev_ifd = length(obs_filepaths)
     for tiffdata in tiffdatas
         try # if this tiffdata specifies the corresponding IFD
             ifd = parse(Int, tiffdata["IFD"]) + 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,30 @@ end
             @test size(img) == (24, 18, 5)
         end
     end
+    @testset "Multi file T stack with multiple OME image nodes" begin
+        # 3 images, each embedded in one OME image node, each with XYCT = (512, 512, 2, 4)
+        # load master file that contains the full OME-XML
+        @testset "Load master file" begin
+            open(abspath(joinpath(testdata_dir, "multiples/multi_image_node/TSeries-camp-005_Cycle00001_Ch1_000001.ome.tif"))) do f
+                s = getstream(format"OMETIFF", f)
+                img = OMETIFF.load(s)
+                @test size(img) == (128, 128, 2, 4, 3)
+                # check channel indexing
+                @test size(img[Axis{:channel}(:Ch1)]) == (128, 128, 4, 3)
+                # check time indexing
+                @test size(img[Axis{:time}(1)]) == (128, 128, 2, 3)
+                # check image indexing
+                @test size(img[Axis{:position}(:Pos1)]) == (128, 128,  2, 4)
+            end
+        end
+        @testset "Load secondary file" begin
+            open(abspath(joinpath(testdata_dir, "multiples/multi_image_node/TSeries-camp-005_Cycle00002_Ch1_000001.ome.tif"))) do f
+                s = getstream(format"OMETIFF", f)
+                img = OMETIFF.load(s)
+                @test size(img) == (128, 128, 2, 4, 3)
+            end
+        end
+    end
 end
 # let's make sure that the values we return are identical to normal TIFF readers
 @testset "TIFF value verifications" begin


### PR DESCRIPTION
Hi there, 

I recently started using OMETIFF for dealing with my microscope recordings in Julia. The package worked great for most of my data, but failed in the case where I collected multiple cycles of time series. Each cycle share the same imaging parameters, and were collected as automatic repetitions over the same FOV. As a neuroscientist, I perform this type of acquisition as I change the experiment condition for each cycle, so I can ask the effect of experiment condition on the neurons in the FOV. This should be a fairly general user case. 

Back to the package, I looked into the code and seemed to have found an one-line bug with potentially broad impact. 

### Error
When there are multiple image nodes in the same ome.tiff, calling load() results in BoundsError. See error message below. 

### Root cause
When there are multiple image nodes (`containers`) in the dataset, the function `ifdindex!` is called for the corresponding number of times. `ifd_indices` and two other outputs are shared across `ifdindex!` calls, but in each call, the indices `ifd` and `prev_ifd` always restart from 1 and 0. As a result, the outputs have the size equal to only one container; information from later image nodes overwrites earlier ones. At the same time, the last index in `ifd_indices` (`pos_idx`) increments to track container/Image ID. When `ifd_indices` were later used to access an one-container-sized array in function `inmemoryarray`, BoundsError is triggered. 

### Fix
Initialize `prev_ifd` in `ifdindex!` as the length of `obs_filepaths`, to reflect the number of existing ifds. 

### Test
The fixed version passes all existing tests in `runtests.jl`. I have provided a folder of dummy images that should allow the error to be reproduced [here](https://github.com/HsupoLeng/exampletiffs/tree/hsupo/multi_image_node), but have not included them in a test, because of the relatively large number of images. 

```julia
julia> imgmeta = load(raw"TSeries_camp-000-ometiff_test\TSeries_camp-000_Cycle00001_Ch1_000001.ome.tif")
Error encountered while load File{DataFormat{:OMETIFF}, String}("TSeries_camp-000-ometiff_test\\TSeries_camp-000_Cycle00001_Ch1_000001.ome.tif").

Fatal error:
ERROR: BoundsError: attempt to access 512×512×1×2×11×1 Array{Gray{N0f16},6} with eltype ColorTypes.Gray{FixedPointNumbers.N0f16} at index [1:512, 1:512, 1, 1, 1, 3]
Stacktrace:
  [1] throw_boundserror(A::Array{ColorTypes.Gray{FixedPointNumbers.N0f16}, 6}, I::Tuple{Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}, Int64, Int64, Int64, Int64})
    @ Base .\abstractarray.jl:651
  [2] checkbounds
    @ .\abstractarray.jl:616 [inlined]
  [3] view(::Array{ColorTypes.Gray{FixedPointNumbers.N0f16}, 6}, ::Function, ::Function, ::Int64, ::Int64, ::Int64, ::Int64)
    @ Base .\subarray.jl:177
  [4] maybeview(::Array{ColorTypes.Gray{FixedPointNumbers.N0f16}, 6}, ::Function, ::Function, ::Vararg{Any, N} where N)
    @ Base .\views.jl:133
  [5] dotview(::Array{ColorTypes.Gray{FixedPointNumbers.N0f16}, 6}, ::Function, ::Function, ::Vararg{Any, N} where N)
    @ Base.Broadcast .\broadcast.jl:1212
  [6] macro expansion
    @ D:\.julia\dev\OMETIFF\src\loader.jl:136 [inlined]
  [7] macro expansion
    @ D:\.julia\packages\ProgressMeter\Vf8un\src\ProgressMeter.jl:940 [inlined]
  [8] inmemoryarray(ifds::OrderedCollections.OrderedDict{NTuple{4, Int64}, Tuple{TiffImages.TiffFile{UInt32, S} where S<:Stream, TiffImages.IFD{UInt32}}}, dims::NamedTuple{(:Y, :X, :Z, :C, :T, :P), NTuple{6, Int64}}; verbose::Bool)
    @ OMETIFF D:\.julia\dev\OMETIFF\src\loader.jl:134
  [9] load(io::Stream{DataFormat{:OMETIFF}, IOStream, String}; dropunused::Bool, verbose::Bool, inmemory::Bool)
    @ OMETIFF D:\.julia\dev\OMETIFF\src\loader.jl:94
 [10] #31
    @ D:\.julia\dev\OMETIFF\src\loader.jl:3 [inlined]
 [11] open(f::OMETIFF.var"#31#32"{Bool, Bool}, args::File{DataFormat{:OMETIFF}, String}; kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Base .\io.jl:330
 [12] open
    @ .\io.jl:328 [inlined]
 [13] #load#30
    @ D:\.julia\dev\OMETIFF\src\loader.jl:2 [inlined]
 [14] load(f::File{DataFormat{:OMETIFF}, String})
    @ OMETIFF D:\.julia\dev\OMETIFF\src\loader.jl:2
 [15] #invokelatest#2
    @ .\essentials.jl:708 [inlined]
 [16] invokelatest
    @ .\essentials.jl:706 [inlined]
 [17] action(::Symbol, ::Vector{Union{Base.PkgId, Module}}, ::Formatted; options::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ FileIO D:\.julia\packages\FileIO\QkYgA\src\loadsave.jl:219
 [18] action
    @ D:\.julia\packages\FileIO\QkYgA\src\loadsave.jl:197 [inlined]
 [19] action(::Symbol, ::Vector{Union{Base.PkgId, Module}}, ::Symbol, ::String; options::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ FileIO D:\.julia\packages\FileIO\QkYgA\src\loadsave.jl:185
 [20] action
    @ D:\.julia\packages\FileIO\QkYgA\src\loadsave.jl:185 [inlined]
 [21] load(::String; options::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ FileIO D:\.julia\packages\FileIO\QkYgA\src\loadsave.jl:113
 [22] load(::String)
    @ FileIO D:\.julia\packages\FileIO\QkYgA\src\loadsave.jl:110
 [23] top-level scope
    @ REPL[10]:1
Stacktrace:
 [1] handle_error(e::BoundsError, q::Base.PkgId, bt::Vector{Union{Ptr{Nothing}, Base.InterpreterIP}})
   @ FileIO D:\.julia\packages\FileIO\QkYgA\src\error_handling.jl:61
 [2] handle_exceptions(exceptions::Vector{Tuple{Any, Union{Base.PkgId, Module}, Vector{T} where T}}, action::String)
   @ FileIO D:\.julia\packages\FileIO\QkYgA\src\error_handling.jl:56
 [3] action(::Symbol, ::Vector{Union{Base.PkgId, Module}}, ::Formatted; options::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ FileIO D:\.julia\packages\FileIO\QkYgA\src\loadsave.jl:228
 [4] action
   @ D:\.julia\packages\FileIO\QkYgA\src\loadsave.jl:197 [inlined]
 [5] action(::Symbol, ::Vector{Union{Base.PkgId, Module}}, ::Symbol, ::String; options::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ FileIO D:\.julia\packages\FileIO\QkYgA\src\loadsave.jl:185
 [6] action
   @ D:\.julia\packages\FileIO\QkYgA\src\loadsave.jl:185 [inlined]
 [7] load(::String; options::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ FileIO D:\.julia\packages\FileIO\QkYgA\src\loadsave.jl:113
 [8] load(::String)
   @ FileIO D:\.julia\packages\FileIO\QkYgA\src\loadsave.jl:110
 [9] top-level scope
   @ REPL[10]:1

julia> 
```