### PR TITLE
increase flexibility around the file extension, see #99

### DIFF
--- a/src/files.jl
+++ b/src/files.jl
@@ -94,6 +94,9 @@ function loadxml(file::TiffFile)
         catch
         end
     end
+    if xml === nothing # if the xml failed to parse or is missing throw an error
+        throw(ErrorException("XML missing or corrupted, aborting"))
+    end
     root(xml)
 end
 

--- a/src/loader.jl
+++ b/src/loader.jl
@@ -27,10 +27,6 @@ Load an OMETIFF file using the stream `io`.
     ```
 """
 function load(io::Stream{format"OMETIFF"}; dropunused=true, verbose = true, inmemory=true)
-    if io.filename !== nothing && !occursin(".ome.tif", io.filename)
-        throw(FileIO.LoaderError("OMETIFF", "Not an OME TIFF file!", ErrorException("")))
-    end
-
     orig_file = read(io, TiffFile)
     summary = load_comments(orig_file)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -241,6 +241,14 @@ end
             @test size(img) == (256, 256, 10, 2)
         end
     end
+    @testset "No .ome.tif ending, Issue #99" begin
+        f = joinpath(testdata_dir, "singles", "single-channel.ome.tif")
+        # change the file ending of an OMETIFF
+        newf = cp(f, splitext(splitext(f)[1])[1] * ".tif", force = true)
+
+        img = FileIO.load(Stream{format"OMETIFF"}(open(newf), newf))
+        @test axisnames(img) == (:y, :x)
+    end
 end
 
 @testset "Issues" begin


### PR DESCRIPTION
This moves the checking of the file to where we're actually searching for the OMEXML instead of doing it early based on the file name.